### PR TITLE
feat: Add support for LinkedIn Jobs Collections page (/jobs/collectio…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "EasyApplyMax",
-  "version": "1.4.1",
-  "description": "Automate LinkedIn Easy Apply job applications with AI-powered smart form filling",
+  "version": "1.5.0",
+  "description": "Automate LinkedIn Easy Apply job applications with AI-powered smart form filling - Supports /jobs/search/ and /jobs/collections/",
   "permissions": [
     "storage",
     "activeTab",


### PR DESCRIPTION
…ns/)

- Add fallback selectors for job cards on collections page
- Extend job title, company, and description selectors for collections layout
- Add multi-method Easy Apply button detection
- Implement infinite scroll support for collections page (vs pagination)
- Add page type detection logging at startup
- Bump version to 1.5.0