### PR TITLE
Add Bolivia (+591) to Latin America & Caribbean country codes

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -161,6 +161,7 @@
             <!-- Latin America & Caribbean -->
             <optgroup label="🌎 Latin America & Caribbean">
               <option value="+54">Argentina (+54)</option>
+              <option value="+591">Bolivia (+591)</option>
               <option value="+55">Brazil (+55)</option>
               <option value="+56">Chile (+56)</option>
               <option value="+57">Colombia (+57)</option>


### PR DESCRIPTION
## Summary
- Added Bolivia (+591) to the Latin America & Caribbean phone country code dropdown in `popup.html`
- Placed in alphabetical order between Argentina and Brazil

Bolivia was missing from the list of available country codes in the region.